### PR TITLE
Fix stream listing with time windows

### DIFF
--- a/lib/cwreader.go
+++ b/lib/cwreader.go
@@ -190,7 +190,11 @@ func getLogStreams(svc *cloudwatchlogs.CloudWatchLogs, group *cloudwatchlogs.Log
 	}
 	sort.Sort(sort.Reverse(ByLastEvent(streams)))
 	if len(streams) == 0 {
-		return nil, fmt.Errorf("No logs found matching task prefix '%s'.  You can get the list of available streams using the `list` command.", streamPrefix)
+		if streamPrefix != "" {
+			return nil, fmt.Errorf("No log streams found matching task prefix '%s' in your time window.  Consider adjusting your time window with --since and/or --until", streamPrefix)
+		} else {
+			return nil, errors.New("No log streams found in your time window.  Consider adjusting your time window with --since and/or --until")
+		}
 	}
 	return streams, nil
 }

--- a/lib/cwreader.go
+++ b/lib/cwreader.go
@@ -213,8 +213,14 @@ type ByLastEvent []*cloudwatchlogs.LogStream
 func (b ByLastEvent) Len() int      { return len(b) }
 func (b ByLastEvent) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 func (b ByLastEvent) Less(i, j int) bool {
-	if b[i].LastEventTimestamp != nil && b[j].LastEventTimestamp != nil {
-		return *b[i].LastEventTimestamp < *b[j].LastEventTimestamp
+	first := b[i].LastEventTimestamp
+	second := b[j].LastEventTimestamp
+
+	if first == nil {
+		first = aws.Int64(0)
 	}
-	return true
+	if second == nil {
+		second = aws.Int64(0)
+	}
+	return *first < *second
 }


### PR DESCRIPTION
There was a bug where log streams with null timestamps for their last event were being mishandled.  This fixes that bug, and also aborts paging through unnecessary streams.