### PR TITLE
remove unecessary sort of log events:

### DIFF
--- a/lib/cwreader.go
+++ b/lib/cwreader.go
@@ -108,7 +108,6 @@ func (c *CloudwatchLogsReader) FetchEvents() ([]Event, error) {
 	}); err != nil {
 		return events, err
 	}
-	sort.Sort(ByCreationTime(events))
 	return events, nil
 }
 


### PR DESCRIPTION
- The API already returns these in sorted order, so the sort just
  wastes time