### PR TITLE
stream log events:

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -102,7 +102,7 @@ func fetch(cmd *cobra.Command, args []string) error {
 
 	eventChan := logReader.StreamEvents(follow)
 
-	ticker := time.After(5 * time.Second)
+	ticker := time.After(7 * time.Second)
 
 ReadLoop:
 	for {
@@ -117,9 +117,11 @@ ReadLoop:
 			}
 			fmt.Fprintf(os.Stdout, "\n")
 			// reset slow log warning timer
-			ticker = time.After(5 * time.Second)
+			ticker = time.After(7 * time.Second)
 		case <-ticker:
-			fmt.Fprintf(os.Stdout, "logs are taking a while to load... possibly try a smaller time window")
+			if !follow {
+				fmt.Fprintf(os.Stdout, "logs are taking a while to load... possibly try a smaller time window")
+			}
 		}
 	}
 

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -100,24 +100,28 @@ func fetch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	eventChan := logReader.StreamEvents(follow)
+
+	ticker := time.After(5 * time.Second)
+
+ReadLoop:
 	for {
-		events, err := logReader.FetchEvents()
-		if err != nil {
-			return err
-		}
-		for _, event := range events {
+		select {
+		case event, ok := <-eventChan:
+			if !ok {
+				break ReadLoop
+			}
 			err = output.Execute(os.Stdout, event)
 			if err != nil {
 				return err
 			}
-			fmt.Fprint(os.Stdout, "\n")
+			fmt.Fprintf(os.Stdout, "\n")
+			// reset slow log warning timer
+			ticker = time.After(5 * time.Second)
+		case <-ticker:
+			fmt.Fprintf(os.Stdout, "logs are taking a while to load... possibly try a smaller time window")
 		}
-		if !follow {
-			if len(events) == 0 {
-				return ErrNoEventsFound
-			}
-			return nil
-		}
-		time.Sleep(5 * time.Second)
 	}
+
+	return logReader.Error()
 }


### PR DESCRIPTION
- This change removes the `FetchEvents` call in favor of
  `StreamEvents` which will stream results over a channel as they are
  retrieved, which heps with responsiveness