### PR TITLE
set a default since duration of 1h:

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -56,7 +56,7 @@ func init() {
 	fetchCmd.Flags().StringVarP(&task, "task", "t", "", "Task UUID or prefix")
 	fetchCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow log streams")
 	fetchCmd.Flags().StringVarP(&eventTemplate, "format", "o", defaultFormatString, "Format template for displaying log events")
-	fetchCmd.Flags().StringVarP(&since, "since", "s", "all", "Fetch logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)")
+	fetchCmd.Flags().StringVarP(&since, "since", "s", "1h", "Fetch logs since timestamp (e.g. 2013-01-02T13:23:37), relative (e.g. 42m for 42 minutes), or all for all logs")
 	fetchCmd.Flags().StringVarP(&until, "until", "u", "now", "Fetch logs until timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)")
 	fetchCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose log output (includes log context in data fields)")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,8 +7,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/segmentio/cwlogs/lib"
+	"github.com/spf13/cobra"
 )
 
 // listCmd represents the list command
@@ -21,7 +21,7 @@ var listCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(listCmd)
 	listCmd.Flags().StringVarP(&task, "task", "t", "", "")
-	listCmd.Flags().StringVarP(&since, "since", "s", "all", "Show logs streams with activity since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)")
+	listCmd.Flags().StringVarP(&since, "since", "s", "1h", "Show logs streams with activity since timestamp (e.g. 2013-01-02T13:23:37), relative (e.g. 42m for 42 minutes), or all for all logs")
 	listCmd.Flags().StringVarP(&until, "until", "u", "now", "Show log streams until timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)")
 }
 


### PR DESCRIPTION
- You can still fetch all logs (for example, from a task), by setting
  `--since` to "all"