### PR TITLE
only gather list of streams if prefix is specified:

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -51,7 +51,7 @@ func list(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	streams := logReader.ListStreams()
+	streams, err := logReader.ListStreams()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- This helps the non `-t` flag case in two ways

1) Because we don't fetch log streams, we call the aws api less, so it's faster.
2) Since we don't filter log streams by last event, we don't miss streams that were updated recently for small --since durations