### PR TITLE
feat: add context to reader for cancellation

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"syscall"
 	"text/template"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/segmentio/cwlogs/lib"
+	"github.com/segmentio/events"
 	"github.com/spf13/cobra"
 )
 
@@ -111,7 +114,10 @@ func fetch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	eventChan := logReader.StreamEvents(follow)
+	ctx, cancel := events.WithSignals(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	eventChan := logReader.StreamEvents(ctx, follow)
 
 	ticker := time.After(7 * time.Second)
 

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -142,5 +142,13 @@ ReadLoop:
 		}
 	}
 
-	return logReader.Error()
+	if err := logReader.Error(); err != nil {
+		if err == context.Canceled {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR adds a context to `CloudwatchLogsReader.StreamEvents()` so that it can be cancelled. Currently, you cannot gracefully stop this operation when you use the `follow` flag.