### PR TITLE
Dividing ecsLogsEvent's time by 1000

### DIFF
--- a/lib/event.go
+++ b/lib/event.go
@@ -35,7 +35,7 @@ func NewEvent(cwEvent cloudwatchlogs.FilteredLogEvent, group string) Event {
 	var ecsLogsEvent ecslogs.Event
 	if err := json.Unmarshal([]byte(*cwEvent.Message), &ecsLogsEvent); err != nil {
 		ecsLogsEvent = ecslogs.MakeEvent(ecslogs.INFO, *cwEvent.Message)
-		ecsLogsEvent.Time = time.Unix(*cwEvent.Timestamp, 0)
+		ecsLogsEvent.Time = ParseAWSTimestamp(cwEvent.Timestamp)
 	}
 
 	return Event{


### PR DESCRIPTION
This PR is fixing `Event.Timestamp` conversion because `cwEvent.Timestamp` is actually milliseconds (rather than seconds from Epoch).

Tested with ECS, Lambda and EC2 agent CloudWatch streams:

Before:
    
    $ aws-vault exec nsw-dmp-nonprod -- ./old-cwlogs fetch my-group/my-stream -o '{{ .Time }}' | tail -n 2
    49790-05-04 10:10:00 +1100 AEDT
    49790-05-04 10:10:00 +1100 AEDT

After:

    $ aws-vault exec nsw-dmp-nonprod -- ./fixed-cwlogs fetch my-group/my-stream -o '{{ .Time }}' | tail -n 2
    2017-10-27 11:28:52 +1100 AEDT
    2017-10-27 11:28:52 +1100 AEDT
