### PR TITLE
feat(cwreader): handle throttling errors more gracefully

### DIFF
--- a/lib/cwreader.go
+++ b/lib/cwreader.go
@@ -36,7 +36,7 @@ type CloudwatchLogsReader struct {
 // end time, and returns a reader for any logs that match those parameters.
 func NewCloudwatchLogsReader(group string, streamPrefix string, start time.Time, end time.Time) (*CloudwatchLogsReader, error) {
 	session := session.New()
-	svc := cloudwatchlogs.New(session)
+	svc := cloudwatchlogs.New(session, &aws.Config{MaxRetries: aws.Int(10)})
 
 	if _, err := getLogGroup(svc, group); err != nil {
 		return nil, err
@@ -124,6 +124,8 @@ func (c *CloudwatchLogsReader) pumpEvents(ctx context.Context, eventChan chan<- 
 			close(eventChan)
 			return
 		}
+
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
I'm getting throttled a good amount, so I think retries are a reasonable thing to add here. In the sdk, we're setting `MaxRetries: 10`, so it'll retry with exponential backoff internally.

To help address throttling as well, I'm loosening up this tight for-loop. Between each iteration of the for loop, there will be a short 100ms delay.