### PR TITLE
Make MaxStreams configurable:

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -40,6 +40,7 @@ var (
 	until         string
 	verbose       bool
 	raw           bool
+	maxStreams    int
 )
 
 // Error messages
@@ -65,6 +66,7 @@ func init() {
 	fetchCmd.Flags().StringVarP(&until, "until", "u", "now", "Fetch logs until timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)")
 	fetchCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose log output (includes log context in data fields)")
 	fetchCmd.Flags().BoolVarP(&raw, "raw", "r", false, "Raw JSON output")
+	fetchCmd.Flags().IntVarP(&maxStreams, "max-streams", "m", 100, "Maximum number of streams to fetch from (for prefix search)")
 }
 
 func fetch(cmd *cobra.Command, args []string) error {
@@ -91,6 +93,8 @@ func fetch(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Failed to parse time '%s'", until)
 		}
 	}
+
+	lib.SetMaxStreams(maxStreams)
 
 	logReader, err := lib.NewCloudwatchLogsReader(args[0], task, start, end)
 	if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -23,6 +23,7 @@ func init() {
 	listCmd.Flags().StringVarP(&task, "task", "t", "", "")
 	listCmd.Flags().StringVarP(&since, "since", "s", "1h", "Show logs streams with activity since timestamp (e.g. 2013-01-02T13:23:37), relative (e.g. 42m for 42 minutes), or all for all logs")
 	listCmd.Flags().StringVarP(&until, "until", "u", "now", "Show log streams until timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)")
+	listCmd.Flags().IntVarP(&maxStreams, "max-streams", "m", 100, "Maximum number of streams to list")
 }
 
 func list(cmd *cobra.Command, args []string) error {
@@ -45,6 +46,8 @@ func list(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Failed to parse time '%s'", until)
 		}
 	}
+
+	lib.SetMaxStreams(maxStreams)
 
 	logReader, err := lib.NewCloudwatchLogsReader(args[0], task, start, end)
 	if err != nil {

--- a/lib/cwreader.go
+++ b/lib/cwreader.go
@@ -16,6 +16,9 @@ import (
 const (
 	// MaxEventsPerCall is the maximum number events from a filter call
 	MaxEventsPerCall = 10000
+)
+
+var (
 	// MaxStreams is the maximum number of streams you can give to a filter call
 	MaxStreams = 100
 )
@@ -30,6 +33,11 @@ type CloudwatchLogsReader struct {
 	end          time.Time
 	error        error
 	streamPrefix string
+}
+
+// Set the maximum number of streams for describe/filter calls
+func SetMaxStreams(max int) {
+	MaxStreams = max
 }
 
 // NewCloudwatchLogsReader takes a group and optionally a stream prefix, start and


### PR DESCRIPTION
- Add a `--max-streams, -m` flag to list and fetch.  Note that for
  fetch's which do not use a `-t`/prefix flag, we can't control the maximum.