### PR TITLE
- use aws timestamp if ecsLogsEvent time is not found #34

### DIFF
--- a/lib/event.go
+++ b/lib/event.go
@@ -35,6 +35,10 @@ func NewEvent(cwEvent cloudwatchlogs.FilteredLogEvent, group string) Event {
 	var ecsLogsEvent ecslogs.Event
 	if err := json.Unmarshal([]byte(*cwEvent.Message), &ecsLogsEvent); err != nil {
 		ecsLogsEvent = ecslogs.MakeEvent(ecslogs.INFO, *cwEvent.Message)
+	}
+
+	// If time was not found use AWS Timestamp
+	if ecsLogsEvent.Time.IsZero() {
 		ecsLogsEvent.Time = ParseAWSTimestamp(cwEvent.Timestamp)
 	}
 


### PR DESCRIPTION
Use the AWS Timestamp for the event if the time is not found. This should work for both non-json and json events that do not use the `Time` field expected by cwlogs.